### PR TITLE
refactor(router): streamline static file handling in RegisterRoutes

### DIFF
--- a/internal/core/router/router.go
+++ b/internal/core/router/router.go
@@ -2,8 +2,6 @@ package router
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/app/server"
@@ -111,23 +109,16 @@ func RegisterRoutes(
 		}
 	}
 
+	// Static files mapping
+	h.StaticFile("/SahariIcon.svg", "./web/dist/SahariIcon.svg")
+	h.StaticFile("/favicon.ico", "./web/dist/favicon.ico")
+	h.StaticFile("/robots.txt", "./web/dist/robots.txt")
+	h.Static("/assets", "./web/dist/assets")
+
 	h.NoRoute(func(ctx context.Context, c *app.RequestContext) {
 		path := string(c.Request.URI().Path())
 		if len(path) >= 4 && path[:4] == "/api" {
 			c.JSON(404, map[string]interface{}{"error": "Not Found"})
-			return
-		}
-
-		// Try to serve static file from dist first (e.g. SahariIcon.svg, robots.txt)
-		// Strip leading slash to make it relative for filepath.Join
-		relPath := path
-		if len(relPath) > 0 && relPath[0] == '/' {
-			relPath = relPath[1:]
-		}
-		distPath := filepath.Join("web/dist", filepath.Clean(relPath))
-		
-		if info, err := os.Stat(distPath); err == nil && !info.IsDir() {
-			c.File(distPath)
 			return
 		}
 


### PR DESCRIPTION
- Remove previous static file serving logic and replace it with direct mappings for specific files (SahariIcon.svg, favicon.ico, robots.txt) and a static directory for assets.
- Simplify the NoRoute handler to serve index.html as a fallback for unmatched routes.