### PR TITLE
refactor(router): update SahariIcon.svg handling in RegisterRoutes

### DIFF
--- a/internal/core/router/router.go
+++ b/internal/core/router/router.go
@@ -109,12 +109,13 @@ func RegisterRoutes(
 		}
 	}
 
-	// Static files mapping
-	// Map /assets prefix to the dist folder (Hertz will look in dist/assets)
 	h.Static("/assets", "./web/dist")
 	
-	// Map root-level files individually for maximum reliability
-	h.StaticFile("/SahariIcon.svg", "./web/dist/SahariIcon.svg")
+	h.GET("/SahariIcon.svg", func(ctx context.Context, c *app.RequestContext) {
+		c.Header("Content-Type", "image/svg+xml")
+		c.File("./web/dist/SahariIcon.svg")
+	})
+	
 	h.StaticFile("/favicon.ico", "./web/dist/favicon.ico")
 	h.StaticFile("/robots.txt", "./web/dist/robots.txt")
 	h.StaticFile("/placeholder.svg", "./web/dist/placeholder.svg")


### PR DESCRIPTION
- Replace static file mapping for SahariIcon.svg with a GET handler to set the correct Content-Type and serve the file.
- Maintain existing static file mappings for favicon.ico, robots.txt, and placeholder.svg to ensure consistent static file serving.