### PR TITLE
Database level

### DIFF
--- a/internal/core/middleware/audit.go
+++ b/internal/core/middleware/audit.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/cloudwego/hertz/pkg/app"
@@ -57,7 +58,30 @@ func (m *AuditMiddleware) Middleware() app.HandlerFunc {
 
 		// Determine action and resource type from method and path
 		action := methodToAction(method)
-		resourceType, resourceID := parseResourceFromPath(path, c)
+		resourceType, resourceID, isListOperation := parseResourceFromPath(path, c)
+
+		// Build audit log details based on operation type
+		var details map[string]interface{}
+		if resourceType == "patient" {
+			if isListOperation {
+				// For list operations, indicate it's a list access
+				details = map[string]interface{}{
+					"operation": "list",
+					"resource":  "patients",
+				}
+				// Try to extract patient count from response body
+				if patientCount := extractPatientCountFromResponse(c); patientCount > 0 {
+					details["patient_count"] = patientCount
+				}
+			} else if resourceID != nil {
+				// For individual patient access, include patient_id in details
+				details = map[string]interface{}{
+					"operation":  "read",
+					"resource":   "patient",
+					"patient_id": resourceID.String(),
+				}
+			}
+		}
 
 		// Get client info
 		ipAddr := c.ClientIP()
@@ -72,7 +96,7 @@ func (m *AuditMiddleware) Middleware() app.HandlerFunc {
 				resourceID,
 				userID,
 				orgID,
-				nil, // details can be enhanced later
+				details,
 				&ipAddr,
 				&userAgent,
 			)
@@ -114,12 +138,14 @@ func isSensitivePath(path string) bool {
 	return sensitiveResources[resource]
 }
 
-func parseResourceFromPath(path string, c *app.RequestContext) (string, *uuid.UUID) {
+// parseResourceFromPath parses the resource type, ID, and determines if it's a list operation
+// Returns: resourceType, resourceID, isListOperation
+func parseResourceFromPath(path string, c *app.RequestContext) (string, *uuid.UUID, bool) {
 	// Path format: /api/v1/{resource}/{id?}
 	parts := strings.Split(strings.Trim(path, "/"), "/")
 
 	if len(parts) < 3 {
-		return "unknown", nil
+		return "unknown", nil, false
 	}
 
 	resourceType := parts[2] // e.g., "patients", "appointments"
@@ -132,9 +158,50 @@ func parseResourceFromPath(path string, c *app.RequestContext) (string, *uuid.UU
 	idParam := c.Param("id")
 	if idParam != "" {
 		if id, err := uuid.Parse(idParam); err == nil {
-			return resourceType, &id
+			// Individual resource access (has ID)
+			return resourceType, &id, false
 		}
 	}
 
-	return resourceType, nil
+	// No ID in path = list operation
+	return resourceType, nil, true
+}
+
+// extractPatientCountFromResponse attempts to extract patient count from the response body
+// Returns 0 if extraction fails or count is not available
+func extractPatientCountFromResponse(c *app.RequestContext) int64 {
+	// Check if response is JSON
+	contentType := string(c.Response.Header.ContentType())
+	if !strings.Contains(contentType, "application/json") {
+		return 0
+	}
+
+	// Get response body
+	body := c.Response.Body()
+	if len(body) == 0 {
+		return 0
+	}
+
+	// Parse JSON response
+	var response struct {
+		Success bool        `json:"success"`
+		Data    interface{} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &response); err != nil {
+		return 0
+	}
+
+	// Extract total from data (data is a map[string]interface{})
+	dataMap, ok := response.Data.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+
+	// Extract total value (JSON numbers are float64)
+	if total, ok := dataMap["total"].(float64); ok {
+		return int64(total)
+	}
+
+	return 0
 }

--- a/internal/modules/audit_log/entity/audit_log.go
+++ b/internal/modules/audit_log/entity/audit_log.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,4 +25,18 @@ type AuditLog struct {
 
 func (AuditLog) TableName() string {
 	return "audit_logs"
+}
+
+// BeforeUpdate is a GORM hook that prevents updates to audit logs
+// This provides application-level protection in addition to database triggers
+func (a *AuditLog) BeforeUpdate(tx *gorm.DB) error {
+	// Audit logs are immutable and cannot be updated
+	return errors.New("cannot update audit logs: audit logs are immutable for compliance and must be retained as-is")
+}
+
+// BeforeDelete is a GORM hook that prevents deletion of audit logs
+// This provides application-level protection in addition to database triggers
+func (a *AuditLog) BeforeDelete(tx *gorm.DB) error {
+	// Audit logs are immutable and cannot be deleted
+	return errors.New("cannot delete audit logs: audit logs are immutable for compliance and must be retained")
 }

--- a/internal/modules/clinical_note/entity/clinical_note.go
+++ b/internal/modules/clinical_note/entity/clinical_note.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -62,4 +63,42 @@ func (Attachment) TableName() string {
 
 func (ClinicalNote) TableName() string {
 	return "clinical_notes"
+}
+
+// BeforeUpdate is a GORM hook that prevents updates to signed notes
+// This provides application-level protection in addition to database triggers
+func (n *ClinicalNote) BeforeUpdate(tx *gorm.DB) error {
+	// Check if the note was already signed before this update
+	// We need to query the database to get the current state
+	var existingNote ClinicalNote
+	if err := tx.Unscoped().Where("id = ?", n.ID).First(&existingNote).Error; err != nil {
+		// If note doesn't exist, allow the operation (it will fail elsewhere)
+		return nil
+	}
+
+	// If the note was already signed, prevent the update
+	if existingNote.IsSigned {
+		return errors.New("cannot update a signed clinical note: signed notes are immutable for compliance")
+	}
+
+	return nil
+}
+
+// BeforeDelete is a GORM hook that prevents deletion of signed notes
+// This provides application-level protection in addition to database triggers
+func (n *ClinicalNote) BeforeDelete(tx *gorm.DB) error {
+	// Check if the note is signed
+	// We need to query the database to get the current state
+	var existingNote ClinicalNote
+	if err := tx.Unscoped().Where("id = ?", n.ID).First(&existingNote).Error; err != nil {
+		// If note doesn't exist, allow the operation (it will fail elsewhere)
+		return nil
+	}
+
+	// If the note is signed, prevent deletion
+	if existingNote.IsSigned {
+		return errors.New("cannot delete a signed clinical note: signed notes are immutable for compliance")
+	}
+
+	return nil
 }

--- a/pkg/migrations/000009_add_note_immutability_triggers.down.sql
+++ b/pkg/migrations/000009_add_note_immutability_triggers.down.sql
@@ -1,0 +1,8 @@
+-- Drop triggers
+DROP TRIGGER IF EXISTS trigger_prevent_signed_note_delete ON clinical_notes;
+DROP TRIGGER IF EXISTS trigger_prevent_signed_note_update ON clinical_notes;
+
+-- Drop functions
+DROP FUNCTION IF EXISTS prevent_signed_note_delete();
+DROP FUNCTION IF EXISTS prevent_signed_note_update();
+

--- a/pkg/migrations/000009_add_note_immutability_triggers.up.sql
+++ b/pkg/migrations/000009_add_note_immutability_triggers.up.sql
@@ -1,0 +1,39 @@
+-- Create function to prevent signed note updates
+CREATE OR REPLACE FUNCTION prevent_signed_note_update()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Check if the note was already signed before this update
+    -- Allow signing (is_signed: false -> true) but prevent any other updates to signed notes
+    IF OLD.is_signed = TRUE THEN
+        RAISE EXCEPTION 'Cannot update a signed clinical note. Signed notes are immutable for compliance.';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create function to prevent signed note deletion
+CREATE OR REPLACE FUNCTION prevent_signed_note_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Check if the note is signed
+    IF OLD.is_signed = TRUE THEN
+        RAISE EXCEPTION 'Cannot delete a signed clinical note. Signed notes are immutable for compliance.';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to prevent signed note updates
+DROP TRIGGER IF EXISTS trigger_prevent_signed_note_update ON clinical_notes;
+CREATE TRIGGER trigger_prevent_signed_note_update
+    BEFORE UPDATE ON clinical_notes
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_signed_note_update();
+
+-- Create trigger to prevent signed note deletion
+DROP TRIGGER IF EXISTS trigger_prevent_signed_note_delete ON clinical_notes;
+CREATE TRIGGER trigger_prevent_signed_note_delete
+    BEFORE DELETE ON clinical_notes
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_signed_note_delete();
+

--- a/pkg/migrations/000010_protect_audit_logs.down.sql
+++ b/pkg/migrations/000010_protect_audit_logs.down.sql
@@ -1,0 +1,8 @@
+-- Drop triggers
+DROP TRIGGER IF EXISTS trigger_prevent_audit_log_update ON audit_logs;
+DROP TRIGGER IF EXISTS trigger_prevent_audit_log_delete ON audit_logs;
+
+-- Drop functions
+DROP FUNCTION IF EXISTS prevent_audit_log_update();
+DROP FUNCTION IF EXISTS prevent_audit_log_delete();
+

--- a/pkg/migrations/000010_protect_audit_logs.up.sql
+++ b/pkg/migrations/000010_protect_audit_logs.up.sql
@@ -1,0 +1,34 @@
+-- Create function to prevent audit log deletion
+CREATE OR REPLACE FUNCTION prevent_audit_log_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Audit logs are immutable and cannot be deleted
+    RAISE EXCEPTION 'Cannot delete audit logs. Audit logs are immutable for compliance and must be retained.';
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to prevent audit log deletion
+DROP TRIGGER IF EXISTS trigger_prevent_audit_log_delete ON audit_logs;
+CREATE TRIGGER trigger_prevent_audit_log_delete
+    BEFORE DELETE ON audit_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_delete();
+
+-- Create function to prevent audit log updates
+CREATE OR REPLACE FUNCTION prevent_audit_log_update()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Audit logs are immutable and cannot be updated
+    RAISE EXCEPTION 'Cannot update audit logs. Audit logs are immutable for compliance and must be retained as-is.';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to prevent audit log updates
+DROP TRIGGER IF EXISTS trigger_prevent_audit_log_update ON audit_logs;
+CREATE TRIGGER trigger_prevent_audit_log_update
+    BEFORE UPDATE ON audit_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_update();
+


### PR DESCRIPTION
This pull request introduces compliance-focused immutability protections for audit logs and signed clinical notes, both at the database and application level. It also enhances audit logging for patient list operations by including additional details such as patient counts. These changes help ensure critical records cannot be modified or deleted, supporting regulatory requirements.

**Immutability protections for compliance**

* Database triggers and functions are added to prevent updates and deletions of audit logs (`audit_logs`) and signed clinical notes (`clinical_notes`). Attempting to modify or delete these records will now raise exceptions at the database level. [[1]](diffhunk://#diff-8669dafbb2b7afcbc34e261e28026ef427b194f17d751fa9cee5ac5efce645bdR1-R39) [[2]](diffhunk://#diff-45fc83a942dfeabb94a2692f81a90ca4bcf22e1a64d49bc21721c677ed4e734aR1-R8) [[3]](diffhunk://#diff-2a2520c7b85dd89810b24dd843630848677053d814491f4f9317b4f77c9c267aR1-R34) [[4]](diffhunk://#diff-301a92d3783bf1c41429948803ed654957125255e4fab047944e0dd34ef92e41R1-R8)
* Application-level GORM hooks are implemented in `AuditLog` and `ClinicalNote` entity models to block updates and deletions, providing an extra layer of protection beyond database triggers. For clinical notes, updates and deletions are only blocked if the note is signed. [[1]](diffhunk://#diff-87e380db638721f3c0ebc4402ddec3d1eac75457988214ee9c59fd5bcc5dabf2R29-R42) [[2]](diffhunk://#diff-54e57dc9fbb4875b8879d5b1f59ee42a9c202abd61c815602cf4f835a77ce847R67-R104)

**Audit logging enhancements**

* The audit middleware now distinguishes between individual patient access and patient list operations, capturing more granular details in audit logs. For list operations, it records the operation type and attempts to extract the patient count from the response body. [[1]](diffhunk://#diff-95f263d7b5d5b92105fcc0f2165447fb7479dc80c1a94e0347ad8be6a314f496L60-R84) [[2]](diffhunk://#diff-95f263d7b5d5b92105fcc0f2165447fb7479dc80c1a94e0347ad8be6a314f496L75-R99)
* Added a helper function to parse resource type, resource ID, and list operation status from request paths, and another to extract patient counts from JSON responses. [[1]](diffhunk://#diff-95f263d7b5d5b92105fcc0f2165447fb7479dc80c1a94e0347ad8be6a314f496L117-R148) [[2]](diffhunk://#diff-95f263d7b5d5b92105fcc0f2165447fb7479dc80c1a94e0347ad8be6a314f496L135-R206)
* Included the `encoding/json` import in the audit middleware to support response parsing.